### PR TITLE
Fix single suppression sync

### DIFF
--- a/src/tap_mailgun/__init__.py
+++ b/src/tap_mailgun/__init__.py
@@ -216,13 +216,15 @@ def sync_single_suppression(stream: str, address: str) -> None:
         suppression_type=stream,
         address=address,
     )
-    suppression['domain_id'] = Context.current_domain_id
-    suppression['created_at'] = singer.utils.strptime_to_utc(
-        suppression['created_at']
-    ).isoformat()
-    time_extracted = singer.utils.now()
-    _transform_and_write_record(suppression, schema, stream, time_extracted)
-    Context.counts[stream] += 1
+
+    if suppression:
+        suppression['domain_id'] = Context.current_domain_id
+        suppression['created_at'] = singer.utils.strptime_to_utc(
+            suppression['created_at']
+        ).isoformat()
+        time_extracted = singer.utils.now()
+        _transform_and_write_record(suppression, schema, stream, time_extracted)
+        Context.counts[stream] += 1
 
 
 def sync_all_suppressions(stream: str) -> None:


### PR DESCRIPTION
## Why are we changing this?

- Tap fails if an admin in Mailgun manually deletes a bounce or other suppression. The tap attempts to sync a suppression that it wasn't able to extract as it no longer exists.

## What has changed?

- Added an if statement to only transform a suppression if it was successfully extracted.